### PR TITLE
Add the missing default scalars Float and ID.

### DIFF
--- a/src/render.ts
+++ b/src/render.ts
@@ -147,7 +147,9 @@ ${this.renderMember(field)}
 var scalars = {
     'String': 'string',
     'Int': 'number',
-    'Boolean': 'boolean'
+    'Float': 'number',
+    'Boolean': 'boolean',
+    'ID': 'string'
 }
 
 /**

--- a/test/schemas/scalars.graphqls
+++ b/test/schemas/scalars.graphqls
@@ -1,5 +1,7 @@
 type Query {
-    stringField: String,
-    booleanField: Boolean,
+    stringField: String
+    booleanField: Boolean
     intField: Int
+    floatField: Float
+    idField: ID
 }

--- a/test/schemas/scalars.ts
+++ b/test/schemas/scalars.ts
@@ -3,5 +3,7 @@ export namespace schema {
         stringField: string | Promise<string> | { (): string } | { (): Promise<string> }
         booleanField: boolean | Promise<boolean> | { (): boolean } | { (): Promise<boolean> }
         intField: number | Promise<number> | { (): number } | { (): Promise<number> }
+        floatField: number | Promise<number> | { (): number } | { (): Promise<number> }
+        idField: string | Promise<string> | { (): string } | { (): Promise<string> }
     }
 }


### PR DESCRIPTION
According to the current graphql docs there are two more scalars than supported currently by `gql2ts-for-server`: Float and ID.

This pull request adds support for them.