### PR TITLE
Required types

### DIFF
--- a/src/render.ts
+++ b/src/render.ts
@@ -119,6 +119,8 @@ ${this.renderMember(field)}
                 return type.name
             case 'LIST':
                 return `${this.renderType(type.ofType)}[]`
+            case 'NON_NULL':
+                return this.renderType(type.ofType)
         }
     }
 

--- a/src/render.ts
+++ b/src/render.ts
@@ -80,10 +80,10 @@ ${this.renderMember(field)}
      * @returns {string}
      */
     renderMember(field: Field) {
-        var typeStr = this.renderType(field.type);
+        var typeStr = this.renderType(field.type, false);
         if (field.args && field.args.length > 0) {
             // Render property with arguments as functions
-            return `${field.name}(args: {${this.renderArgumentType(field.args)}}): ${this.renderDirectTypes(typeStr)}`
+            return `${field.name}(args: {${this.renderArgumentType(field.args)}}): ${this.renderDirectTypes(typeStr, false)}`
         } else {
             // Render property as field, with the option of being of a function-type () => ReturnValue
             const optional = field.type.kind !== 'NON_NULL'
@@ -96,7 +96,7 @@ ${this.renderMember(field)}
      * Render the type of a field on all variants (promises, methods etc)
      * @param type
      */
-    renderDirectTypes(typeStr: string, optional: boolean = false) {
+    renderDirectTypes(typeStr: string, optional: boolean) {
         if (optional) {
             return `${typeStr} | Promise<${typeStr} | undefined>`
         } else {
@@ -109,7 +109,7 @@ ${this.renderMember(field)}
      * @param typeStr
      * @returns {string}
      */
-    renderFunctionTypes(typeStr: string, optional: boolean = false) {
+    renderFunctionTypes(typeStr: string, optional: boolean) {
         if (optional) {
             return `{ (): ${typeStr} | undefined } | { (): Promise<${typeStr} | undefined> }`
         } else {
@@ -121,7 +121,7 @@ ${this.renderMember(field)}
      * Render a single return type (or field type)
      * This function creates the base type that is then used as generic to a promise
      */
-    renderType(type, optional = false) {
+    renderType(type, optional: boolean) {
         function wrap(arg) {
             return optional ? `(${arg} | undefined)` : arg
         }
@@ -153,7 +153,7 @@ ${this.renderMember(field)}
      */
     renderArgumentType(args: Argument[]) {
         return args.map((arg) => {
-            return `${arg.name}: ${this.renderType(arg.type)}`
+            return `${arg.name}: ${this.renderType(arg.type, false)}`
         }).join(', ')
     }
 

--- a/test/schemas/required.graphqls
+++ b/test/schemas/required.graphqls
@@ -8,6 +8,8 @@ type Query {
     requiredIntField: Int!
     requiredObjectField: A!
 
-    requiredList: [String]!
+    requiredListOfOptionals: [String]!
+    optionalListOfOptionals: [String]
     requiredListOfRequired: [String!]!
+    optionalListOfRequired: [String!]
 }

--- a/test/schemas/required.graphqls
+++ b/test/schemas/required.graphqls
@@ -1,0 +1,13 @@
+type A {
+  name: String!
+}
+
+type Query {
+    requiredStringField: String!
+    optionalStringField: String
+    requiredIntField: Int!
+    requiredObjectField: A!
+
+    requiredList: [String]!
+    requiredListOfRequired: [String!]!
+}

--- a/test/schemas/required.ts
+++ b/test/schemas/required.ts
@@ -1,11 +1,13 @@
 export namespace schema {
     export interface Query {
         requiredStringField: string | Promise<string> | { (): string } | { (): Promise<string> }
-        optionalStringField: string | Promise<string> | { (): string } | { (): Promise<string> }
+        optionalStringField?: string | Promise<string | undefined> | { (): string | undefined } | { (): Promise<string | undefined> }
         requiredIntField: number | Promise<number> | { (): number } | { (): Promise<number> }
         requiredObjectField: A | Promise<A> | { (): A } | { (): Promise<A> }
-        requiredList: string[] | Promise<string[]> | { (): string[] } | { (): Promise<string[]> }
+        requiredListOfOptionals: (string | undefined)[] | Promise<(string | undefined)[]> | { (): (string | undefined)[] } | { (): Promise<(string | undefined)[]> }
+        optionalListOfOptionals?: (string | undefined)[] | Promise<(string | undefined)[] | undefined> | { (): (string | undefined)[] | undefined } | { (): Promise<(string | undefined)[] | undefined> }
         requiredListOfRequired: string[] | Promise<string[]> | { (): string[] } | { (): Promise<string[]> }
+        optionalListOfRequired?: string[] | Promise<string[] | undefined> | { (): string[] | undefined } | { (): Promise<string[] | undefined> }
     }
 
     export interface A {

--- a/test/schemas/required.ts
+++ b/test/schemas/required.ts
@@ -1,0 +1,14 @@
+export namespace schema {
+    export interface Query {
+        requiredStringField: string | Promise<string> | { (): string } | { (): Promise<string> }
+        optionalStringField: string | Promise<string> | { (): string } | { (): Promise<string> }
+        requiredIntField: number | Promise<number> | { (): number } | { (): Promise<number> }
+        requiredObjectField: A | Promise<A> | { (): A } | { (): Promise<A> }
+        requiredList: string[] | Promise<string[]> | { (): string[] } | { (): Promise<string[]> }
+        requiredListOfRequired: string[] | Promise<string[]> | { (): string[] } | { (): Promise<string[]> }
+    }
+
+    export interface A {
+        name: string | Promise<string> | { (): string } | { (): Promise<string> }
+    }
+}

--- a/test/schemas/scalars.ts
+++ b/test/schemas/scalars.ts
@@ -1,9 +1,9 @@
 export namespace schema {
     export interface Query {
-        stringField: string | Promise<string> | { (): string } | { (): Promise<string> }
-        booleanField: boolean | Promise<boolean> | { (): boolean } | { (): Promise<boolean> }
-        intField: number | Promise<number> | { (): number } | { (): Promise<number> }
-        floatField: number | Promise<number> | { (): number } | { (): Promise<number> }
-        idField: string | Promise<string> | { (): string } | { (): Promise<string> }
+        stringField?: string | Promise<string | undefined> | { (): string | undefined } | { (): Promise<string | undefined> }
+        booleanField?: boolean | Promise<boolean | undefined> | { (): boolean | undefined } | { (): Promise<boolean | undefined> }
+        intField?: number | Promise<number | undefined> | { (): number | undefined } | { (): Promise<number | undefined> }
+        floatField?: number | Promise<number | undefined> | { (): number | undefined } | { (): Promise<number | undefined> }
+        idField?: string | Promise<string | undefined> | { (): string | undefined } | { (): Promise<string | undefined> }
     }
 }

--- a/test/schemas/simpleSchema.ts
+++ b/test/schemas/simpleSchema.ts
@@ -3,11 +3,11 @@ export namespace schema {
         /**
          * A field description
          */
-        field1: TypeA | Promise<TypeA> | { (): TypeA } | { (): Promise<TypeA> }
+        field1?: TypeA | Promise<TypeA | undefined> | { (): TypeA | undefined } | { (): Promise<TypeA | undefined> }
         /**
          * Another field description
          */
-        field2: TypeB | Promise<TypeB> | { (): TypeB } | { (): Promise<TypeB> }
+        field2?: TypeB | Promise<TypeB | undefined> | { (): TypeB | undefined } | { (): Promise<TypeB | undefined> }
     }
 
     /**
@@ -15,14 +15,14 @@ export namespace schema {
      * Multiline description
      */
     export interface TypeA {
-        name: string | Promise<string> | { (): string } | { (): Promise<string> }
-        size: number | Promise<number> | { (): number } | { (): Promise<number> }
+        name?: string | Promise<string | undefined> | { (): string | undefined } | { (): Promise<string | undefined> }
+        size?: number | Promise<number | undefined> | { (): number | undefined } | { (): Promise<number | undefined> }
     }
 
     /**
      * Another more complex type
      */
     export interface TypeB {
-        nested: TypeA[] | Promise<TypeA[]> | { (): TypeA[] } | { (): Promise<TypeA[]> }
+        nested?: (TypeA | undefined)[] | Promise<(TypeA | undefined)[] | undefined> | { (): (TypeA | undefined)[] | undefined } | { (): Promise<(TypeA | undefined)[] | undefined> }
     }
 }


### PR DESCRIPTION
GraphQL support requiring certain fields by suffixing the types with an exclamation mark (i.e. `name: String!`. Currently this types are not handled and are interpreted as `undefined`.

This pull request adds support for the non-null fields.

Note that it also changes the handling of the default (aka optional) fields: 
- it makes them optional in typescript by suffixing a question mark to the member
- it allows the promise or function to return undefined (eg `string | undefined`)
- it also allows `undefined` in arrays if the elements are not non-null (eg `(string | undefined)[]`)
Because of this changes it also supports compiling the code with Typescript's `strictNullChecks` flag set to on.