### PR TITLE
Add support for enum types in the schema.

### DIFF
--- a/src/model.ts
+++ b/src/model.ts
@@ -12,14 +12,14 @@ export interface Root {
 
 export interface TypeDef {
     name: string
-    kind: "SCALAR" | "OBJECT" | "NON_NULL" | "LIST"
+    kind: "SCALAR" | "OBJECT" | "NON_NULL" | "LIST" | "ENUM"
     description: string
-    fields: Field[]
+    fields?: Field[]
+    enumValues?: EnumValue[]
 
     // Not yet considered
     inputFields: any
     interfaces: any[]
-    enumValues: any
     possibleTypes: any
 }
 
@@ -40,7 +40,14 @@ export class Argument {
 }
 
 export class Type {
-    kind: "SCALAR" | "OBJECT" | "NON_NULL" | "LIST"
+    kind: "SCALAR" | "OBJECT" | "NON_NULL" | "LIST" | "ENUM"
     name: string
     ofType: Type
+}
+
+export class EnumValue {
+    name: string
+    description: string
+    deprecated: boolean
+    deprecationReason?: string
 }

--- a/test/schemas/arguments.ts
+++ b/test/schemas/arguments.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 export namespace schema {
+
     export interface Query {
         field1(args: {a: string, b: number}): string | Promise<string>
     }

--- a/test/schemas/enum.graphqls
+++ b/test/schemas/enum.graphqls
@@ -1,0 +1,11 @@
+enum STATE {
+  OPEN
+  CLOSED
+  # permanently deleted
+  DELETED
+}
+
+type Query {
+  state: STATE!
+  optionalState: STATE
+}

--- a/test/schemas/enum.ts
+++ b/test/schemas/enum.ts
@@ -1,0 +1,21 @@
+/* tslint:disable */
+export namespace schema {
+    export type STATE = 'OPEN' | 'CLOSED' | 'DELETED'
+    export const STATE: {
+        OPEN: 'OPEN',
+        CLOSED: 'CLOSED',
+        DELETED: 'DELETED',
+    } = {
+        OPEN: 'OPEN',
+        CLOSED: 'CLOSED',
+        /**
+         * permanently deleted
+         */
+        DELETED: 'DELETED',
+    }
+
+    export interface Query {
+        state: STATE | Promise<STATE> | { (): STATE } | { (): Promise<STATE> }
+        optionalState?: STATE | Promise<STATE | undefined> | { (): STATE | undefined } | { (): Promise<STATE | undefined> }
+    }
+}

--- a/test/schemas/required.ts
+++ b/test/schemas/required.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 export namespace schema {
+
     export interface Query {
         requiredStringField: string | Promise<string> | { (): string } | { (): Promise<string> }
         optionalStringField?: string | Promise<string | undefined> | { (): string | undefined } | { (): Promise<string | undefined> }

--- a/test/schemas/scalars.ts
+++ b/test/schemas/scalars.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 export namespace schema {
+
     export interface Query {
         stringField?: string | Promise<string | undefined> | { (): string | undefined } | { (): Promise<string | undefined> }
         booleanField?: boolean | Promise<boolean | undefined> | { (): boolean | undefined } | { (): Promise<boolean | undefined> }

--- a/test/schemas/simpleSchema.ts
+++ b/test/schemas/simpleSchema.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 export namespace schema {
+
     export interface Query {
         /**
          * A field description


### PR DESCRIPTION
Add support for GraphQL enums.

The enums are not represented as typescript enums because then you'd have to map every (integer) value to its string representation. Instead we use a union of strings (e.g. `'one' | 'two'`).