### PR TITLE
Added tslint-config and fix reported problems

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -13,16 +13,13 @@ end_of_line = lf
 insert_final_newline = false
 trim_trailing_whitespace = false
 
-[*.{js,php}]
-indent_size = 2
+[*.ts]
+indent_size = 4
 insert_final_newline = true
 trim_trailing_whitespace = true
 
-[*.{php,html}]
-indent_size = 4
-
 [*.{json,cson,yml,yaml,html,md,jade,css,stylus}]
-indent_size = 2
+indent_size = 4
 
 [Makefile]
 indent_size = 2

--- a/bin/gql2ts-for-server.js
+++ b/bin/gql2ts-for-server.js
@@ -4,24 +4,23 @@ const program = require("commander");
 const runCli_1 = require("../src/runCli");
 function stringArray(arg, message) {
     if (!arg) {
-        throw new Error(message + ": Value not set");
+        throw new Error(`${message}: Value not set`);
     }
     if (arg instanceof Array && arg.length === 0 || typeof arg[0] === 'string') {
         return arg;
     }
-    throw new Error(message + ": Not a string[]");
+    throw new Error(message + ': Not a string[]');
 }
 program.version(require('../package.json').version)
     .description('Convert all .graphqls schema-files in the current directory tree into typescript\n' +
     'interfaces that can be used to implement a graphql-root for this schema.')
-    .option('-x, --exclude <dirs>', 'a list of directories to exclude', (current, last) => {
-    return last.concat([current]);
-}, ['node_modules'])
-    .option('--dont-save-same-file', 'do not save a file if the contents has not changed. This read each target file prior to loading')
+    .option('-x, --exclude <dirs>', 'a list of directories to exclude', (current, last) => last.concat([current]), ['node_modules'])
+    .option('--dont-save-same-file', 'do not save a file if the contents has not changed. ' +
+    'This read each target file prior to loading')
     .parse(process.argv);
 runCli_1.runCli({
     exclude: stringArray(program['exclude'], "Verification of 'exclude'-parameter"),
     dontSaveSameFile: Boolean(program['dontSaveSameFile'])
 })
-    .then(() => console.log("done"));
+    .then(() => console.log('done'));
 //# sourceMappingURL=gql2ts-for-server.js.map

--- a/bin/gql2ts-for-server.ts
+++ b/bin/gql2ts-for-server.ts
@@ -5,27 +5,30 @@ import {runCli} from '../src/runCli'
 
 function stringArray(arg: any, message: string): string[] {
     if (!arg) {
-        throw new Error(message +": Value not set") 
+        throw new Error(`${message}: Value not set`)
     }
     if (arg instanceof Array && arg.length === 0 || typeof arg[0] === 'string') {
         return arg
     }
-    throw new Error(message + ": Not a string[]")
+    throw new Error(message + ': Not a string[]')
 }
 
 program.version(require('../package.json').version)
     .description(
         'Convert all .graphqls schema-files in the current directory tree into typescript\n' +
         'interfaces that can be used to implement a graphql-root for this schema.')
-    .option('-x, --exclude <dirs>', 'a list of directories to exclude', (current, last) => {
-        return last.concat([current])
-    }, ['node_modules'])
-    .option('--dont-save-same-file', 'do not save a file if the contents has not changed. This read each target file prior to loading')
+    .option(
+      '-x, --exclude <dirs>',
+      'a list of directories to exclude',
+      (current, last) => last.concat([current]),
+      ['node_modules'])
+    .option(
+      '--dont-save-same-file', 'do not save a file if the contents has not changed. ' +
+      'This read each target file prior to loading')
     .parse(process.argv)
-
 
 runCli({
     exclude: stringArray(program['exclude'],"Verification of 'exclude'-parameter"),
     dontSaveSameFile: Boolean(program['dontSaveSameFile'])
 })
-.then(() => console.log("done"))
+.then(() => console.log('done'))

--- a/examples/example-usage.ts
+++ b/examples/example-usage.ts
@@ -1,6 +1,6 @@
-import {graphql, buildSchema}  from 'graphql'
+import {graphql, buildSchema} from 'graphql'
 import {schema} from './graphql/schema/example.graphqls'
-import fs = require('fs')
+import * as fs from 'fs'
 
 // Implement the generated interface
 class Root implements schema.Query {
@@ -28,7 +28,7 @@ class Person implements schema.Person {
 
 // Run a query
 graphql(
-    buildSchema(fs.readFileSync('graphql/schema/example.graphqls', { encoding: 'utf-8' })),
+    buildSchema(fs.readFileSync('graphql/schema/example.graphqls', {encoding: 'utf-8'})),
     '{ person(name:"Joye") { name age friends { name age } }}',
     new Root()
-).then((result) => console.log(JSON.stringify(result,null,2)))
+).then((result) => console.log(JSON.stringify(result, null, 2)))

--- a/package.json
+++ b/package.json
@@ -23,13 +23,14 @@
   "license": "MIT",
   "scripts": {
     "compile": "tsc",
-    "test": "mocha",
+    "tslint": "tslint -e '**/*.d.ts' -e 'node_modules/**' '**/*.ts'",
+    "test": "mocha && npm run tslint",
     "thought": "thought run -a",
     "prethoughtcheck": "thought --version || npm -g install thought",
     "thoughtcheck": "thought check-engines",
     "version": "thoughtful changelog -o -a && npm run thought",
     "preversion": "npm run thoughtcheck",
-    "prepublish": "tsc"
+    "prepublish": "tsc && npm run test"
   },
   "dependencies": {
     "commander": "^2.9.0",
@@ -50,6 +51,7 @@
     "mocha": "^2.3.3",
     "thoughtful-release": "^0.3.0",
     "ts-node": "^1.7.0",
+    "tslint-config-standard": "^2.0.0",
     "typescript": "^2.1.1"
   },
   "files": [

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "main": "src/index.js",
   "license": "MIT",
   "scripts": {
-    "compile": "tsc",
+    "compile": "tsc --noUnusedLocals",
     "tslint": "tslint -e '**/*.d.ts' -e 'node_modules/**' '**/*.ts'",
     "test": "mocha && npm run tslint",
     "thought": "thought run -a",
@@ -30,7 +30,7 @@
     "thoughtcheck": "thought check-engines",
     "version": "thoughtful changelog -o -a && npm run thought",
     "preversion": "npm run thoughtcheck",
-    "prepublish": "tsc && npm run test"
+    "prepublish": "npm run compile && npm run test"
   },
   "dependencies": {
     "commander": "^2.9.0",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,9 @@
     "mocha": "^2.3.3",
     "thoughtful-release": "^0.3.0",
     "ts-node": "^1.7.0",
+    "tslint": "^4.3.1",
     "tslint-config-standard": "^2.0.0",
+    "tslint-eslint-rules": "^3.2.3",
     "typescript": "^2.1.1"
   },
   "files": [

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,26 +5,22 @@
  * Released under the MIT license.
  */
 
-import path = require('path')
 import {graphql, introspectionQuery, buildSchema} from 'graphql'
-import fs = require('fs')
-import stream = require('stream')
 import {Renderer} from './render'
 
 /**
  * The converter class
  */
 export class Converter {
-
     /**
      * Converts a graphQL schema into a TypeScript interface.
      * @param graphqls the source code of the graphQL schema
      * @return a Promise for the TypeScript source code.
      */
     public async convert(graphqls: string): Promise<string> {
-        var schema: any = buildSchema(graphqls)
-        var renderer = new Renderer({})
-        var introSpection: any = await graphql(schema, introspectionQuery, {})
+        const schema: any = buildSchema(graphqls)
+        const renderer = new Renderer({})
+        const introSpection: any = await graphql(schema, introspectionQuery, {})
         return renderer.render(introSpection)
     }
 }

--- a/src/model.ts
+++ b/src/model.ts
@@ -6,7 +6,7 @@ export interface Root {
     }
 }
 
-export type Kind = "SCALAR" | "OBJECT" | "NON_NULL" | "LIST" | "ENUM" | "UNION"
+export type Kind = 'SCALAR' | 'OBJECT' | 'NON_NULL' | 'LIST' | 'ENUM' | 'UNION'
 
 /**
  * Model definition of the introspection result

--- a/src/render.ts
+++ b/src/render.ts
@@ -1,4 +1,4 @@
-import {Root, TypeDef, Field, Type, Argument, EnumValue} from './model'
+import {Root, TypeDef, Field, Argument, EnumValue} from './model'
 import {source, OMIT_NEXT_NEWLINE} from './renderTag'
 
 export interface Options {
@@ -12,9 +12,9 @@ export class Renderer {
      * Types that are not created as interface, because they are part of the introspection
      */
     private introspectionTypes: {[key: string]: boolean} = setOf([
-        "__Schema", "__Type", "__TypeKind", "__Field", "__InputValue", "__EnumValue",
-        "__Directive", "__DirectiveLocation"
-    ]);
+        '__Schema', '__Type', '__TypeKind', '__Field', '__InputValue', '__EnumValue',
+        '__Directive', '__DirectiveLocation'
+    ])
 
     constructor(options: Options) {
         this.options = options
@@ -33,7 +33,6 @@ export namespace schema {
     ${this.renderUnions(root.data.__schema.types)}
     ${this.renderTypes(root.data.__schema.types)}
 }
-
 `
         return result.replace(/^\s+$/mg, '')
     }
@@ -83,15 +82,18 @@ ${this.renderMember(field)}
      * @returns {string}
      */
     renderMember(field: Field) {
-        var typeStr = this.renderType(field.type, false);
+        const typeStr = this.renderType(field.type, false)
         if (field.args && field.args.length > 0) {
             // Render property with arguments as functions
-            return `${field.name}(args: {${this.renderArgumentType(field.args)}}): ${this.renderDirectTypes(typeStr, false)}`
+            const argType = this.renderArgumentType(field.args)
+            return `${field.name}(args: {${argType}}): ${this.renderDirectTypes(typeStr, false)}`
         } else {
             // Render property as field, with the option of being of a function-type () => ReturnValue
             const optional = field.type.kind !== 'NON_NULL'
             const name = optional ? field.name + '?' : field.name
-            return `${name}: ${this.renderDirectTypes(typeStr, optional)} | ${this.renderFunctionTypes(typeStr, optional)}`
+            const directTypes = this.renderDirectTypes(typeStr, optional)
+            const functionTypes = this.renderFunctionTypes(typeStr, optional)
+            return `${name}: ${directTypes} | ${functionTypes}`
         }
     }
 
@@ -128,6 +130,7 @@ ${this.renderMember(field)}
         function wrap(arg) {
             return optional ? `(${arg} | undefined)` : arg
         }
+
         switch (type.kind) {
             case 'SCALAR':
                 return wrap(scalars[type.name])
@@ -150,7 +153,7 @@ ${this.renderMember(field)}
             // Parsed by the `source` tag-function to remove the next newline
             return OMIT_NEXT_NEWLINE
         }
-        return `/**\n * ` + description.split('\n').join(`\n * `) + `\n */`;
+        return `/**\n * ` + description.split('\n').join(`\n * `) + `\n */`
     }
 
     /**
@@ -240,7 +243,7 @@ export type ${type.name} = ${unionValues}
     }
 }
 
-var scalars = {
+const scalars = {
     'String': 'string',
     'Int': 'number',
     'Float': 'number',
@@ -254,8 +257,10 @@ var scalars = {
  * @returns {{}}
  */
 function setOf(array: string[]): {[key: string]: boolean} {
-    return array.reduce((set, current): {[key: string]: boolean} => {
-        set[current] = true;
-        return set;
-    }, {})
+    return array.reduce(
+        (set, current): {[key: string]: boolean} => {
+            set[current] = true
+            return set
+        },
+        {})
 }

--- a/src/renderTag.ts
+++ b/src/renderTag.ts
@@ -14,9 +14,15 @@ export const OMIT_NEXT_NEWLINE = {
  * and expands the current indent on multiline substitions
  * @see http://exploringjs.com/es6/ch_template-literals.html
  * @param array the input array
- * @param args
+ * @param a1 string substitution
+ * @param a2 string substitution
+ * @param a2 string substitution
+ * @param a3 string substitution
+ * @param a4 string substitution
+ * @param a5 string substitution
+ * @param a6 string substitution
  */
-export function source(array /* dynamic args */) {
+export function source(array, a1, a2?, a3?, a4?, a5?, a6? /* dynamic args */) {
     const args = Array.prototype.slice.call(arguments, 1)
     let result = array[0]
     for (let i = 0; i < args.length; i++) {

--- a/src/renderTag.ts
+++ b/src/renderTag.ts
@@ -1,4 +1,4 @@
-var spaces = '                                                                                       '
+const spaces = '                                                                                       '
 
 /**
  * Token that removes whitespace following the substition up to and including the next newline character
@@ -13,15 +13,14 @@ export const OMIT_NEXT_NEWLINE = {
  * Removes the first and last character, if it is a newline
  * and expands the current indent on multiline substitions
  * @see http://exploringjs.com/es6/ch_template-literals.html
- * @param array
+ * @param array the input array
  * @param args
  */
-export function source(array, a1, a2?, a3?, a4?, a5?, a6? /** dynamic args **/) {
-    var args = Array.prototype.slice.call(arguments, 1)
-    var result = array[0]
-    for (var i = 0; i < args.length; i++) {
+export function source(array, ...args /* dynamic args */) {
+    let result = array[0]
+    for (let i = 0; i < args.length; i++) {
         // Determine indent
-        var indent = result.length - result.lastIndexOf('\n') - 1
+        const indent = result.length - result.lastIndexOf('\n') - 1
         switch (args[i]) {
             case OMIT_NEXT_NEWLINE:
                 result += array[i + 1].replace(/^ *\n/, '')
@@ -34,15 +33,15 @@ export function source(array, a1, a2?, a3?, a4?, a5?, a6? /** dynamic args **/) 
 
     result = result.replace(/(^\n|\n$)/g, '')
 
-    var templateTag = array[0].match(/\s*\n([ \t])*##+ TEMPLATE ##+\s*$/m);
+    const templateTag = array[0].match(/\s*\n([ \t])*##+ TEMPLATE ##+\s*$/m)
     if (templateTag) {
         // Determine de-indent
-        var deindent = templateTag[1].length - templateTag[1].lastIndexOf('\n') - 1
+        const deindent = templateTag[1].length - templateTag[1].lastIndexOf('\n') - 1
         return result
             .substr
             .split('\n')
             .map((line) => line.substr(deindent))
     }
 
-    return result;
+    return result
 }

--- a/src/renderTag.ts
+++ b/src/renderTag.ts
@@ -16,7 +16,8 @@ export const OMIT_NEXT_NEWLINE = {
  * @param array the input array
  * @param args
  */
-export function source(array, ...args /* dynamic args */) {
+export function source(array /* dynamic args */) {
+    const args = Array.prototype.slice.call(arguments, 1)
     let result = array[0]
     for (let i = 0; i < args.length; i++) {
         // Determine indent

--- a/src/runCli.ts
+++ b/src/runCli.ts
@@ -1,7 +1,7 @@
 import glob = require('glob')
-import {Converter}from './index'
-import fs = require('fs')
-var mfs = require('m-io/fs')
+import {Converter} from './index'
+// Import via ES 5, node-style 'require', because there are no typings for this file (yet)
+const mfs = require('m-io/fs')
 
 export interface CliArgs {
     /**
@@ -11,29 +11,29 @@ export interface CliArgs {
     dontSaveSameFile: boolean
 }
 
-export async function runCli(cliArgs: CliArgs):Promise<any> {
+export async function runCli(cliArgs: CliArgs): Promise<any> {
 
     // Remove default value from 'exclude', if explicit values have been provided
     if (cliArgs.exclude.length > 1) {
-        cliArgs.exclude.shift();
+        cliArgs.exclude.shift()
     }
 
-    var files = glob.sync('**/*.graphqls', {
+    const files = glob.sync('**/*.graphqls', {
         ignore: cliArgs.exclude
-    });
+    })
 
-    var converter = new Converter()
+    const converter = new Converter()
 
-    var promises = files.map(async (sourceFile) => {
-        var targetFile = sourceFile + '.ts'
+    const promises = files.map(async (sourceFile) => {
+        const targetFile = sourceFile + '.ts'
         try {
-            var source = await mfs.read(sourceFile, {encoding: 'utf-8'})
-            var ts = await converter.convert(source)
+            const source = await mfs.read(sourceFile, {encoding: 'utf-8'})
+            const ts = await converter.convert(source)
             if (cliArgs.dontSaveSameFile) {
-                var oldContents = await mfs.read(targetFile)
+                const oldContents = await mfs.read(targetFile)
                 if (oldContents === ts) {
                     console.log(`${sourceFile} -> ${targetFile}`, 'success')
-                    return 
+                    return
                 }
             }
             await mfs.write(targetFile, ts)

--- a/test/converter-spec.ts
+++ b/test/converter-spec.ts
@@ -15,7 +15,7 @@ import path = require('path')
 import fs = require('fs')
 import {expect} from 'chai'
 
-var converter = new Converter()
+const converter = new Converter()
 
 function fixture(filename) {
     return path.join(__dirname, 'schemas', filename)
@@ -25,22 +25,20 @@ function store(file, code) {
 }
 
 function read(file) {
-    return fs.readFileSync(file, {encoding: 'utf-8'})
+    return fs.readFileSync(file, {encoding: 'utf-8'}).trim()
 }
-
-
 
 describe('gql2ts-for-server:', function () {
     // Automatic generation of tests from the testcases-directory
     fs.readdirSync(path.join(__dirname, 'schemas'))
         .filter((file) => file.match(/\.graphqls$/))
         .forEach((file) => {
-            
-            it(`should handle ${file} correctly`, async function () {
-                var source = fixture(file)
-                var target = source.replace(/\.graphqls$/,'.ts');
 
-                var result = await converter.convert(read(source));
+            it(`should handle ${file} correctly`, async function () {
+                const source = fixture(file)
+                const target = source.replace(/\.graphqls$/,'.ts')
+
+                const result = await converter.convert(read(source))
                 // If the target file does not exist yet, we write it
                 // with a short disclaimer, so that the test does not pass
                 if (!fs.existsSync(target)) {

--- a/test/renderTag-spec.ts
+++ b/test/renderTag-spec.ts
@@ -1,24 +1,24 @@
-import {source, OMIT_NEXT_NEWLINE} from '../src/renderTag';
+import {source, OMIT_NEXT_NEWLINE} from '../src/renderTag'
 import {expect} from 'chai'
 
-describe("The renderTag function", function () {
-    it("should render simple template literals like the default template literal", function () {
+describe('The renderTag function', function () {
+    it('should render simple template literals like the default template literal', function () {
         expect(source`ein ${'einfacher'} string ${2}`).to.equal('ein einfacher string 2')
     })
 
-    it("should skip the first and the last newline of the result", function () {
+    it('should skip the first and the last newline of the result', function () {
         expect(source`\nein ${'einfacher'} string ${2}\n`).to.equal('ein einfacher string 2')
     })
 
-    it("should skip no more than the first and the last newline of the result", function () {
+    it('should skip no more than the first and the last newline of the result', function () {
         expect(source`\n\nein ${'einfacher'} string ${2}\n\n`).to.equal('\nein einfacher string 2\n')
     })
 
-    it("should indent multiline replacements with the indent of the substitution", function () {
+    it('should indent multiline replacements with the indent of the substitution', function () {
         expect(source`abc\n   ${'multiline\nsubstitution'}`).to.equal('abc\n   multiline\n   substitution')
     })
 
-    it("should omit whitespace and the next newline after a OMIT_NEXT_NEWLINE substitution", function () {
+    it('should omit whitespace and the next newline after a OMIT_NEXT_NEWLINE substitution', function () {
         expect(source`abc${OMIT_NEXT_NEWLINE}   \nabc`).to.equal('abcabc')
     })
 })

--- a/test/usability-spec.ts
+++ b/test/usability-spec.ts
@@ -10,7 +10,6 @@
 // /* global xdescribe */
 // /* global xit */
 
-import {Converter} from '../src/index'
 import path = require('path')
 import fs = require('fs')
 import {expect} from 'chai'
@@ -21,10 +20,6 @@ import {schema as argumentSchema} from './schemas/arguments'
 function fixture(filename) {
     return path.join(__dirname, 'schemas', filename)
 }
-function store(file, code) {
-    return fs.writeFileSync(file, code)
-}
-
 function read(file) {
     return fs.readFileSync(file, {encoding: 'utf-8'})
 }
@@ -33,12 +28,12 @@ describe('The simple schema', function () {
 
     // Automatic generation of tests from the testcases-directory
     it('should be possible to use with graphql', async function () {
-        var schema = buildSchema(read(fixture('simpleSchema.graphqls')));
+        const schema = buildSchema(read(fixture('simpleSchema.graphqls')))
 
-        var root: simpleSchema.Query = {
+        const root: simpleSchema.Query = {
             field1: {
                 name: 'abc',
-                size: () => 4,
+                size: () => 4
             },
             field2: Promise.resolve({
                 nested: [
@@ -49,20 +44,22 @@ describe('The simple schema', function () {
                 ]
             })
         }
-        var result = await graphql(schema, `
-                {
-                    field1 {
+        const result = await graphql(
+            schema,
+            `{
+                field1 {
+                    name
+                    size
+                }
+                field2 {
+                    nested {
                         name
                         size
                     }
-                    field2 {
-                        nested {
-                            name
-                            size
-                        }
-                    }
-                }`, root)
-        expect(result, "Checking simple schema result").to.deep.equal({
+                }
+            }`,
+            root)
+        expect(result, 'Checking simple schema result').to.deep.equal({
             data: {
 
                 field1: {
@@ -81,35 +78,39 @@ describe('The simple schema', function () {
 })
 
 describe('The arguments schema', async function () {
-    var schema = buildSchema(read(fixture('arguments.graphqls')));
-    var root: argumentSchema.Query = {
+    const schema = buildSchema(read(fixture('arguments.graphqls')))
+    const root: argumentSchema.Query = {
         field1: (args: {a: string, b: number}) => {
-            return args.a + " " + args.b
+            return args.a + ' ' + args.b
         }
     }
 
     it('Test with default argument', async function () {
-        var result = await graphql(schema, `
-                {
-                    field1(a:"b")
-                }`, root)
+        const result = await graphql(
+            schema,
+            `{
+                field1(a:"b")
+            }`,
+            root)
 
-        expect(result, "Checking arguments-schema with default argument").to.deep.equal({
+        expect(result, 'Checking arguments-schema with default argument').to.deep.equal({
             data: {
-                field1: "b 3"
+                field1: 'b 3'
             }
         })
     })
 
     it('Test with explicit argument', async function () {
-        var result = await graphql(schema, `
-                {
-                    field1(a:"b",b:4)
-                }`, root)
+        const result = await graphql(
+            schema,
+            `{
+                field1(a:"b",b:4)
+            }`,
+            root)
 
-        expect(result, "Checking arguments-schema with default argument").to.deep.equal({
+        expect(result, 'Checking arguments-schema with default argument').to.deep.equal({
             data: {
-                field1: "b 4"
+                field1: 'b 4'
             }
         })
     })

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,20 +1,25 @@
-
 {
-  "compilerOptions": {
-    "target": "es6",
-    "module": "commonjs",
-    "lib": [ "es6" ],
-    "types": [ "node", "mocha" ],
-    "rootDir": "src",
-    "declaration": true,
-    "moduleResolution": "node",
-    "sourceMap": true,
-    "emitDecoratorMetadata": true,
-    "experimentalDecorators": true,
-    "removeComments": false,
-    "noImplicitAny": false
-  },
-  "exclude": [
-    "node_modules"
-  ]
+    "compilerOptions": {
+        "target": "es6",
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "types": [
+            "node",
+            "mocha"
+        ],
+        "rootDir": "src",
+        "declaration": true,
+        "moduleResolution": "node",
+        "sourceMap": true,
+        "emitDecoratorMetadata": true,
+        "experimentalDecorators": true,
+        "removeComments": false,
+        "noImplicitAny": false,
+        "noUnusedLocals": true  
+    },
+    "exclude": [
+        "node_modules"
+    ]
 }

--- a/tslint.json
+++ b/tslint.json
@@ -8,7 +8,6 @@
                 "SwitchCase": 1
             }
         ],
-        "prefer-const": true,
-        "no-unused-variable": true
+        "prefer-const": true
     }
 }

--- a/tslint.json
+++ b/tslint.json
@@ -1,0 +1,14 @@
+{
+    "extends": "tslint-config-standard",
+    "rules": {
+        "ter-indent": [
+            true,
+            4,
+            {
+                "SwitchCase": 1
+            }
+        ],
+        "prefer-const": true,
+        "no-unused-variable": true
+    }
+}


### PR DESCRIPTION
- Useed 'tslint-config-standard' with some custom rules
- Added 'tslint' as npm-script
- Ran 'npm run tslint' along with 'npm test'
- Adapted '.editorconfig'-file to tslint-config
- Fixed errors detected by tslint.
   This sadly means that almost all files are touched in this commit, with mostly white-space changes
   In the future, this will hopefully not happen anymore

The tslint-config depends on 'tslint-config-standard',
which seems to be the most-popular base-configuration for tslint.