### PR TITLE
docs: Unescape "<" in verbatim-part of the README

### DIFF
--- a/.thought/partials/usage.md.hbs
+++ b/.thought/partials/usage.md.hbs
@@ -17,9 +17,9 @@ will be converted into the following `example.graphqls.ts`:
 Note that all the field (non-argument) types can either be
 
 * the actual type (`Person`),
-* a promise for the actual type (`Promise&lt;Person>`),
+* a promise for the actual type (`Promise<Person>`),
 * a function generating the actual type (`(): Person`), or
-* a function generating a Promise (`(): Promise&lt;Person>`)  
+* a function generating a Promise (`(): Promise<Person>`)  
 
 For fields with arguments, only the latter two apply.
 

--- a/README.md
+++ b/README.md
@@ -96,9 +96,9 @@ export namespace schema {
 Note that all the field (non-argument) types can either be
 
 * the actual type (`Person`),
-* a promise for the actual type (`Promise&lt;Person>`),
+* a promise for the actual type (`Promise<Person>`),
 * a function generating the actual type (`(): Person`), or
-* a function generating a Promise (`(): Promise&lt;Person>`)  
+* a function generating a Promise (`(): Promise<Person>`)  
 
 For fields with arguments, only the latter two apply.
 


### PR DESCRIPTION
- Github does not escape &lt; inside backtick strings
   https://github.com/nknapp/gql2ts-for-server/tree/a49d40023b4d7ea6ab8c8dc39420c93637723532#readme