### PR TITLE
Different declaration of resolver arguments.

### DIFF
--- a/examples/graphql/schema/example.graphqls.ts
+++ b/examples/graphql/schema/example.graphqls.ts
@@ -1,31 +1,33 @@
 /* tslint:disable */
+
 export namespace schema {
+    export type Resolver<Args, Result, Ctx> = Result | Promise<Result> | ((args: Args, context: Ctx) => Result | Promise<Result>)
 
     /**
      * The base query
      */
-    export interface Query {
+    export interface Query<Ctx> {
         /**
          * Retrieve a person by name
          */
-        person(args: {name: string}): Person | Promise<Person>
+        person?: Resolver<{name: string}, Person<Ctx> | undefined, Ctx>
     }
 
     /**
      * A type describing a person
      */
-    export interface Person {
+    export interface Person<Ctx> {
         /**
          * The persons name
          */
-        name: string | Promise<string> | { (): string } | { (): Promise<string> }
+        name: Resolver<{}, string, Ctx>
         /**
          * The persons age in years
          */
-        age: number | Promise<number> | { (): number } | { (): Promise<number> }
+        age: Resolver<{}, number, Ctx>
         /**
          * Friendship relations to other persons
          */
-        friends?: Person[] | Promise<Person[] | undefined> | { (): Person[] | undefined } | { (): Promise<Person[] | undefined> }
+        friends?: Resolver<{}, Person<Ctx>[] | undefined, Ctx>
     }
 }

--- a/src/render.ts
+++ b/src/render.ts
@@ -74,6 +74,11 @@ export interface ${type.name}<Ctx> ${this.renderExtends(type)}{
 `
     }
 
+    /**
+     * Renders the extends clause of an interface (e.g. 'extends A, B. C').
+     * @param type
+     * @returns
+     */
     renderExtends(type: TypeDef): string {
         if (type.interfaces && type.interfaces.length > 0) {
             const interfaces = type.interfaces.map((it) => `${it.name}<Ctx>`).join(', ')
@@ -114,7 +119,7 @@ ${this.renderMember(field)}
      * This function creates the base type that is then used as generic to a promise
      */
     renderType(type, optional: boolean) {
-        function opt(arg) {
+        function maybeOptional(arg) {
             return optional ? `(${arg} | undefined)` : arg
         }
         function generic(arg) {
@@ -123,16 +128,16 @@ ${this.renderMember(field)}
 
         switch (type.kind) {
             case 'SCALAR':
-                return opt(scalars[type.name])
+                return maybeOptional(scalars[type.name])
             case 'ENUM':
             case 'INPUT_OBJECT':
-                return opt(type.name)
+                return maybeOptional(type.name)
             case 'OBJECT':
             case 'UNION':
             case 'INTERFACE':
-                return opt(generic(type.name))
+                return maybeOptional(generic(type.name))
             case 'LIST':
-                return opt(`${this.renderType(type.ofType, true)}[]`)
+                return maybeOptional(`${this.renderType(type.ofType, true)}[]`)
             case 'NON_NULL':
                 return this.renderType(type.ofType, false)
         }

--- a/test/schemas/arguments.ts
+++ b/test/schemas/arguments.ts
@@ -1,7 +1,12 @@
 /* tslint:disable */
+
 export namespace schema {
+    export type Resolver<Args, Result> =
+        Result |
+        Promise<Result> |
+        ((root: any, args: Args, context: any) => Result | Promise<Result>)
 
     export interface Query {
-        field1(args: {a: string, b: number}): string | Promise<string>
+        field1?: Resolver<{a: string, b: number}, string | undefined>
     }
 }

--- a/test/schemas/arguments.ts
+++ b/test/schemas/arguments.ts
@@ -1,12 +1,9 @@
 /* tslint:disable */
 
 export namespace schema {
-    export type Resolver<Args, Result> =
-        Result |
-        Promise<Result> |
-        ((root: any, args: Args, context: any) => Result | Promise<Result>)
+    export type Resolver<Args, Result, Ctx> = Result | Promise<Result> | ((args: Args, context: Ctx) => Result | Promise<Result>)
 
-    export interface Query {
-        field1?: Resolver<{a: string, b: number}, string | undefined>
+    export interface Query<Ctx> {
+        field1?: Resolver<{a: string, b: number}, string | undefined, Ctx>
     }
 }

--- a/test/schemas/enum.ts
+++ b/test/schemas/enum.ts
@@ -1,5 +1,11 @@
 /* tslint:disable */
+
 export namespace schema {
+    export type Resolver<Args, Result> =
+        Result |
+        Promise<Result> |
+        ((root: any, args: Args, context: any) => Result | Promise<Result>)
+
     export type STATE = 'OPEN' | 'CLOSED' | 'DELETED'
     export const STATE: {
         OPEN: 'OPEN',
@@ -15,7 +21,7 @@ export namespace schema {
     }
 
     export interface Query {
-        state: STATE | Promise<STATE> | { (): STATE } | { (): Promise<STATE> }
-        optionalState?: STATE | Promise<STATE | undefined> | { (): STATE | undefined } | { (): Promise<STATE | undefined> }
+        state: Resolver<{}, STATE>
+        optionalState?: Resolver<{}, STATE | undefined>
     }
 }

--- a/test/schemas/enum.ts
+++ b/test/schemas/enum.ts
@@ -1,10 +1,7 @@
 /* tslint:disable */
 
 export namespace schema {
-    export type Resolver<Args, Result> =
-        Result |
-        Promise<Result> |
-        ((root: any, args: Args, context: any) => Result | Promise<Result>)
+    export type Resolver<Args, Result, Ctx> = Result | Promise<Result> | ((args: Args, context: Ctx) => Result | Promise<Result>)
 
     export type STATE = 'OPEN' | 'CLOSED' | 'DELETED'
     export const STATE: {
@@ -20,8 +17,8 @@ export namespace schema {
         DELETED: 'DELETED',
     }
 
-    export interface Query {
-        state: Resolver<{}, STATE>
-        optionalState?: Resolver<{}, STATE | undefined>
+    export interface Query<Ctx> {
+        state: Resolver<{}, STATE, Ctx>
+        optionalState?: Resolver<{}, STATE | undefined, Ctx>
     }
 }

--- a/test/schemas/interface.ts
+++ b/test/schemas/interface.ts
@@ -1,30 +1,35 @@
 /* tslint:disable */
+
 export namespace schema {
+    export type Resolver<Args, Result> =
+        Result |
+        Promise<Result> |
+        ((root: any, args: Args, context: any) => Result | Promise<Result>)
 
     /**
      * A character
      */
     export interface Character {
-        id: string | Promise<string> | { (): string } | { (): Promise<string> }
-        name: string | Promise<string> | { (): string } | { (): Promise<string> }
+        id: Resolver<{}, string>
+        name: Resolver<{}, string>
     }
     export interface Functional {
-        primaryFunction?: string | Promise<string | undefined> | { (): string | undefined } | { (): Promise<string | undefined> }
+        primaryFunction?: Resolver<{}, string | undefined>
     }
 
     export interface Query {
-        characters?: (Character | undefined)[] | Promise<(Character | undefined)[] | undefined> | { (): (Character | undefined)[] | undefined } | { (): Promise<(Character | undefined)[] | undefined> }
+        characters?: Resolver<{}, (Character | undefined)[] | undefined>
     }
 
     export interface Human extends Character {
-        id: string | Promise<string> | { (): string } | { (): Promise<string> }
-        name: string | Promise<string> | { (): string } | { (): Promise<string> }
-        friends?: (Character | undefined)[] | Promise<(Character | undefined)[] | undefined> | { (): (Character | undefined)[] | undefined } | { (): Promise<(Character | undefined)[] | undefined> }
+        id: Resolver<{}, string>
+        name: Resolver<{}, string>
+        friends?: Resolver<{}, (Character | undefined)[] | undefined>
     }
 
     export interface Droid extends Character, Functional {
-        id: string | Promise<string> | { (): string } | { (): Promise<string> }
-        name: string | Promise<string> | { (): string } | { (): Promise<string> }
-        primaryFunction?: string | Promise<string | undefined> | { (): string | undefined } | { (): Promise<string | undefined> }
+        id: Resolver<{}, string>
+        name: Resolver<{}, string>
+        primaryFunction?: Resolver<{}, string | undefined>
     }
 }

--- a/test/schemas/interface.ts
+++ b/test/schemas/interface.ts
@@ -1,35 +1,32 @@
 /* tslint:disable */
 
 export namespace schema {
-    export type Resolver<Args, Result> =
-        Result |
-        Promise<Result> |
-        ((root: any, args: Args, context: any) => Result | Promise<Result>)
+    export type Resolver<Args, Result, Ctx> = Result | Promise<Result> | ((args: Args, context: Ctx) => Result | Promise<Result>)
 
     /**
      * A character
      */
-    export interface Character {
-        id: Resolver<{}, string>
-        name: Resolver<{}, string>
+    export interface Character<Ctx> {
+        id: Resolver<{}, string, Ctx>
+        name: Resolver<{}, string, Ctx>
     }
-    export interface Functional {
-        primaryFunction?: Resolver<{}, string | undefined>
-    }
-
-    export interface Query {
-        characters?: Resolver<{}, (Character | undefined)[] | undefined>
+    export interface Functional<Ctx> {
+        primaryFunction?: Resolver<{}, string | undefined, Ctx>
     }
 
-    export interface Human extends Character {
-        id: Resolver<{}, string>
-        name: Resolver<{}, string>
-        friends?: Resolver<{}, (Character | undefined)[] | undefined>
+    export interface Query<Ctx> {
+        characters?: Resolver<{}, (Character<Ctx> | undefined)[] | undefined, Ctx>
     }
 
-    export interface Droid extends Character, Functional {
-        id: Resolver<{}, string>
-        name: Resolver<{}, string>
-        primaryFunction?: Resolver<{}, string | undefined>
+    export interface Human<Ctx> extends Character<Ctx> {
+        id: Resolver<{}, string, Ctx>
+        name: Resolver<{}, string, Ctx>
+        friends?: Resolver<{}, (Character<Ctx> | undefined)[] | undefined, Ctx>
+    }
+
+    export interface Droid<Ctx> extends Character<Ctx>, Functional<Ctx> {
+        id: Resolver<{}, string, Ctx>
+        name: Resolver<{}, string, Ctx>
+        primaryFunction?: Resolver<{}, string | undefined, Ctx>
     }
 }

--- a/test/schemas/mutation.ts
+++ b/test/schemas/mutation.ts
@@ -1,5 +1,10 @@
 /* tslint:disable */
+
 export namespace schema {
+    export type Resolver<Args, Result> =
+        Result |
+        Promise<Result> |
+        ((root: any, args: Args, context: any) => Result | Promise<Result>)
 
     /**
      * Set a key to a value
@@ -9,16 +14,16 @@ export namespace schema {
         value?: string
     }
     export interface Query {
-        values?: (KeyValue | undefined)[] | Promise<(KeyValue | undefined)[] | undefined> | { (): (KeyValue | undefined)[] | undefined } | { (): Promise<(KeyValue | undefined)[] | undefined> }
+        values?: Resolver<{}, (KeyValue | undefined)[] | undefined>
     }
 
     export interface KeyValue {
-        key: string | Promise<string> | { (): string } | { (): Promise<string> }
-        value?: string | Promise<string | undefined> | { (): string | undefined } | { (): Promise<string | undefined> }
+        key: Resolver<{}, string>
+        value?: Resolver<{}, string | undefined>
     }
 
     export interface Mutation {
-        simpleMutation(args: {key: string, value: string}): (KeyValue | undefined)[] | Promise<(KeyValue | undefined)[]>
-        commandMutation(args: {cmd: SetValueCommand}): (KeyValue | undefined)[] | Promise<(KeyValue | undefined)[]>
+        simpleMutation?: Resolver<{key: string, value: string}, (KeyValue | undefined)[] | undefined>
+        commandMutation?: Resolver<{cmd: SetValueCommand}, (KeyValue | undefined)[] | undefined>
     }
 }

--- a/test/schemas/mutation.ts
+++ b/test/schemas/mutation.ts
@@ -1,10 +1,7 @@
 /* tslint:disable */
 
 export namespace schema {
-    export type Resolver<Args, Result> =
-        Result |
-        Promise<Result> |
-        ((root: any, args: Args, context: any) => Result | Promise<Result>)
+    export type Resolver<Args, Result, Ctx> = Result | Promise<Result> | ((args: Args, context: Ctx) => Result | Promise<Result>)
 
     /**
      * Set a key to a value
@@ -13,17 +10,17 @@ export namespace schema {
         key: string
         value?: string
     }
-    export interface Query {
-        values?: Resolver<{}, (KeyValue | undefined)[] | undefined>
+    export interface Query<Ctx> {
+        values?: Resolver<{}, (KeyValue<Ctx> | undefined)[] | undefined, Ctx>
     }
 
-    export interface KeyValue {
-        key: Resolver<{}, string>
-        value?: Resolver<{}, string | undefined>
+    export interface KeyValue<Ctx> {
+        key: Resolver<{}, string, Ctx>
+        value?: Resolver<{}, string | undefined, Ctx>
     }
 
-    export interface Mutation {
-        simpleMutation?: Resolver<{key: string, value: string}, (KeyValue | undefined)[] | undefined>
-        commandMutation?: Resolver<{cmd: SetValueCommand}, (KeyValue | undefined)[] | undefined>
+    export interface Mutation<Ctx> {
+        simpleMutation?: Resolver<{key: string, value: string}, (KeyValue<Ctx> | undefined)[] | undefined, Ctx>
+        commandMutation?: Resolver<{cmd: SetValueCommand}, (KeyValue<Ctx> | undefined)[] | undefined, Ctx>
     }
 }

--- a/test/schemas/required.ts
+++ b/test/schemas/required.ts
@@ -1,18 +1,23 @@
 /* tslint:disable */
+
 export namespace schema {
+    export type Resolver<Args, Result> =
+        Result |
+        Promise<Result> |
+        ((root: any, args: Args, context: any) => Result | Promise<Result>)
 
     export interface Query {
-        requiredStringField: string | Promise<string> | { (): string } | { (): Promise<string> }
-        optionalStringField?: string | Promise<string | undefined> | { (): string | undefined } | { (): Promise<string | undefined> }
-        requiredIntField: number | Promise<number> | { (): number } | { (): Promise<number> }
-        requiredObjectField: A | Promise<A> | { (): A } | { (): Promise<A> }
-        requiredListOfOptionals: (string | undefined)[] | Promise<(string | undefined)[]> | { (): (string | undefined)[] } | { (): Promise<(string | undefined)[]> }
-        optionalListOfOptionals?: (string | undefined)[] | Promise<(string | undefined)[] | undefined> | { (): (string | undefined)[] | undefined } | { (): Promise<(string | undefined)[] | undefined> }
-        requiredListOfRequired: string[] | Promise<string[]> | { (): string[] } | { (): Promise<string[]> }
-        optionalListOfRequired?: string[] | Promise<string[] | undefined> | { (): string[] | undefined } | { (): Promise<string[] | undefined> }
+        requiredStringField: Resolver<{}, string>
+        optionalStringField?: Resolver<{}, string | undefined>
+        requiredIntField: Resolver<{}, number>
+        requiredObjectField: Resolver<{}, A>
+        requiredListOfOptionals: Resolver<{}, (string | undefined)[]>
+        optionalListOfOptionals?: Resolver<{}, (string | undefined)[] | undefined>
+        requiredListOfRequired: Resolver<{}, string[]>
+        optionalListOfRequired?: Resolver<{}, string[] | undefined>
     }
 
     export interface A {
-        name: string | Promise<string> | { (): string } | { (): Promise<string> }
+        name: Resolver<{}, string>
     }
 }

--- a/test/schemas/required.ts
+++ b/test/schemas/required.ts
@@ -1,23 +1,20 @@
 /* tslint:disable */
 
 export namespace schema {
-    export type Resolver<Args, Result> =
-        Result |
-        Promise<Result> |
-        ((root: any, args: Args, context: any) => Result | Promise<Result>)
+    export type Resolver<Args, Result, Ctx> = Result | Promise<Result> | ((args: Args, context: Ctx) => Result | Promise<Result>)
 
-    export interface Query {
-        requiredStringField: Resolver<{}, string>
-        optionalStringField?: Resolver<{}, string | undefined>
-        requiredIntField: Resolver<{}, number>
-        requiredObjectField: Resolver<{}, A>
-        requiredListOfOptionals: Resolver<{}, (string | undefined)[]>
-        optionalListOfOptionals?: Resolver<{}, (string | undefined)[] | undefined>
-        requiredListOfRequired: Resolver<{}, string[]>
-        optionalListOfRequired?: Resolver<{}, string[] | undefined>
+    export interface Query<Ctx> {
+        requiredStringField: Resolver<{}, string, Ctx>
+        optionalStringField?: Resolver<{}, string | undefined, Ctx>
+        requiredIntField: Resolver<{}, number, Ctx>
+        requiredObjectField: Resolver<{}, A<Ctx>, Ctx>
+        requiredListOfOptionals: Resolver<{}, (string | undefined)[], Ctx>
+        optionalListOfOptionals?: Resolver<{}, (string | undefined)[] | undefined, Ctx>
+        requiredListOfRequired: Resolver<{}, string[], Ctx>
+        optionalListOfRequired?: Resolver<{}, string[] | undefined, Ctx>
     }
 
-    export interface A {
-        name: Resolver<{}, string>
+    export interface A<Ctx> {
+        name: Resolver<{}, string, Ctx>
     }
 }

--- a/test/schemas/scalars.ts
+++ b/test/schemas/scalars.ts
@@ -1,11 +1,16 @@
 /* tslint:disable */
+
 export namespace schema {
+    export type Resolver<Args, Result> =
+        Result |
+        Promise<Result> |
+        ((root: any, args: Args, context: any) => Result | Promise<Result>)
 
     export interface Query {
-        stringField?: string | Promise<string | undefined> | { (): string | undefined } | { (): Promise<string | undefined> }
-        booleanField?: boolean | Promise<boolean | undefined> | { (): boolean | undefined } | { (): Promise<boolean | undefined> }
-        intField?: number | Promise<number | undefined> | { (): number | undefined } | { (): Promise<number | undefined> }
-        floatField?: number | Promise<number | undefined> | { (): number | undefined } | { (): Promise<number | undefined> }
-        idField?: string | Promise<string | undefined> | { (): string | undefined } | { (): Promise<string | undefined> }
+        stringField?: Resolver<{}, string | undefined>
+        booleanField?: Resolver<{}, boolean | undefined>
+        intField?: Resolver<{}, number | undefined>
+        floatField?: Resolver<{}, number | undefined>
+        idField?: Resolver<{}, string | undefined>
     }
 }

--- a/test/schemas/scalars.ts
+++ b/test/schemas/scalars.ts
@@ -1,16 +1,13 @@
 /* tslint:disable */
 
 export namespace schema {
-    export type Resolver<Args, Result> =
-        Result |
-        Promise<Result> |
-        ((root: any, args: Args, context: any) => Result | Promise<Result>)
+    export type Resolver<Args, Result, Ctx> = Result | Promise<Result> | ((args: Args, context: Ctx) => Result | Promise<Result>)
 
-    export interface Query {
-        stringField?: Resolver<{}, string | undefined>
-        booleanField?: Resolver<{}, boolean | undefined>
-        intField?: Resolver<{}, number | undefined>
-        floatField?: Resolver<{}, number | undefined>
-        idField?: Resolver<{}, string | undefined>
+    export interface Query<Ctx> {
+        stringField?: Resolver<{}, string | undefined, Ctx>
+        booleanField?: Resolver<{}, boolean | undefined, Ctx>
+        intField?: Resolver<{}, number | undefined, Ctx>
+        floatField?: Resolver<{}, number | undefined, Ctx>
+        idField?: Resolver<{}, string | undefined, Ctx>
     }
 }

--- a/test/schemas/simpleSchema.ts
+++ b/test/schemas/simpleSchema.ts
@@ -1,15 +1,20 @@
 /* tslint:disable */
+
 export namespace schema {
+    export type Resolver<Args, Result> =
+        Result |
+        Promise<Result> |
+        ((root: any, args: Args, context: any) => Result | Promise<Result>)
 
     export interface Query {
         /**
          * A field description
          */
-        field1?: TypeA | Promise<TypeA | undefined> | { (): TypeA | undefined } | { (): Promise<TypeA | undefined> }
+        field1?: Resolver<{}, TypeA | undefined>
         /**
          * Another field description
          */
-        field2?: TypeB | Promise<TypeB | undefined> | { (): TypeB | undefined } | { (): Promise<TypeB | undefined> }
+        field2?: Resolver<{}, TypeB | undefined>
     }
 
     /**
@@ -17,14 +22,14 @@ export namespace schema {
      * Multiline description
      */
     export interface TypeA {
-        name?: string | Promise<string | undefined> | { (): string | undefined } | { (): Promise<string | undefined> }
-        size?: number | Promise<number | undefined> | { (): number | undefined } | { (): Promise<number | undefined> }
+        name?: Resolver<{}, string | undefined>
+        size?: Resolver<{}, number | undefined>
     }
 
     /**
      * Another more complex type
      */
     export interface TypeB {
-        nested?: (TypeA | undefined)[] | Promise<(TypeA | undefined)[] | undefined> | { (): (TypeA | undefined)[] | undefined } | { (): Promise<(TypeA | undefined)[] | undefined> }
+        nested?: Resolver<{}, (TypeA | undefined)[] | undefined>
     }
 }

--- a/test/schemas/simpleSchema.ts
+++ b/test/schemas/simpleSchema.ts
@@ -1,35 +1,32 @@
 /* tslint:disable */
 
 export namespace schema {
-    export type Resolver<Args, Result> =
-        Result |
-        Promise<Result> |
-        ((root: any, args: Args, context: any) => Result | Promise<Result>)
+    export type Resolver<Args, Result, Ctx> = Result | Promise<Result> | ((args: Args, context: Ctx) => Result | Promise<Result>)
 
-    export interface Query {
+    export interface Query<Ctx> {
         /**
          * A field description
          */
-        field1?: Resolver<{}, TypeA | undefined>
+        field1?: Resolver<{}, TypeA<Ctx> | undefined, Ctx>
         /**
          * Another field description
          */
-        field2?: Resolver<{}, TypeB | undefined>
+        field2?: Resolver<{}, TypeB<Ctx> | undefined, Ctx>
     }
 
     /**
      * A simple type
      * Multiline description
      */
-    export interface TypeA {
-        name?: Resolver<{}, string | undefined>
-        size?: Resolver<{}, number | undefined>
+    export interface TypeA<Ctx> {
+        name?: Resolver<{}, string | undefined, Ctx>
+        size?: Resolver<{}, number | undefined, Ctx>
     }
 
     /**
      * Another more complex type
      */
-    export interface TypeB {
-        nested?: Resolver<{}, (TypeA | undefined)[] | undefined>
+    export interface TypeB<Ctx> {
+        nested?: Resolver<{}, (TypeA<Ctx> | undefined)[] | undefined, Ctx>
     }
 }

--- a/test/schemas/union.ts
+++ b/test/schemas/union.ts
@@ -1,5 +1,10 @@
 /* tslint:disable */
+
 export namespace schema {
+    export type Resolver<Args, Result> =
+        Result |
+        Promise<Result> |
+        ((root: any, args: Args, context: any) => Result | Promise<Result>)
 
     export type Single = A
 
@@ -9,15 +14,15 @@ export namespace schema {
     export type AOrB = A | B
 
     export interface Query {
-        single?: Single | Promise<Single | undefined> | { (): Single | undefined } | { (): Promise<Single | undefined> }
-        aOrB?: AOrB | Promise<AOrB | undefined> | { (): AOrB | undefined } | { (): Promise<AOrB | undefined> }
+        single?: Resolver<{}, Single | undefined>
+        aOrB?: Resolver<{}, AOrB | undefined>
     }
 
     export interface A {
-        aName?: string | Promise<string | undefined> | { (): string | undefined } | { (): Promise<string | undefined> }
+        aName?: Resolver<{}, string | undefined>
     }
 
     export interface B {
-        bName?: string | Promise<string | undefined> | { (): string | undefined } | { (): Promise<string | undefined> }
+        bName?: Resolver<{}, string | undefined>
     }
 }

--- a/test/schemas/union.ts
+++ b/test/schemas/union.ts
@@ -1,28 +1,25 @@
 /* tslint:disable */
 
 export namespace schema {
-    export type Resolver<Args, Result> =
-        Result |
-        Promise<Result> |
-        ((root: any, args: Args, context: any) => Result | Promise<Result>)
+    export type Resolver<Args, Result, Ctx> = Result | Promise<Result> | ((args: Args, context: Ctx) => Result | Promise<Result>)
 
-    export type Single = A
+    export type Single<Ctx> = A<Ctx>
 
     /**
      * A or B
      */
-    export type AOrB = A | B
+    export type AOrB<Ctx> = A<Ctx> | B<Ctx>
 
-    export interface Query {
-        single?: Resolver<{}, Single | undefined>
-        aOrB?: Resolver<{}, AOrB | undefined>
+    export interface Query<Ctx> {
+        single?: Resolver<{}, Single<Ctx> | undefined, Ctx>
+        aOrB?: Resolver<{}, AOrB<Ctx> | undefined, Ctx>
     }
 
-    export interface A {
-        aName?: Resolver<{}, string | undefined>
+    export interface A<Ctx> {
+        aName?: Resolver<{}, string | undefined, Ctx>
     }
 
-    export interface B {
-        bName?: Resolver<{}, string | undefined>
+    export interface B<Ctx> {
+        bName?: Resolver<{}, string | undefined, Ctx>
     }
 }

--- a/test/usability-spec.ts
+++ b/test/usability-spec.ts
@@ -30,7 +30,7 @@ describe('The simple schema', function () {
     it('should be possible to use with graphql', async function () {
         const schema = buildSchema(read(fixture('simpleSchema.graphqls')))
 
-        const root: simpleSchema.Query = {
+        const root: simpleSchema.Query<{}> = {
             field1: {
                 name: 'abc',
                 size: () => 4
@@ -79,7 +79,7 @@ describe('The simple schema', function () {
 
 describe('The arguments schema', async function () {
     const schema = buildSchema(read(fixture('arguments.graphqls')))
-    const root: argumentSchema.Query = {
+    const root: argumentSchema.Query<{}> = {
         field1: (args: {a: string, b: number}) => {
             return args.a + ' ' + args.b
         }


### PR DESCRIPTION
Also see #16 

I've done a rewrite by introducing a `Resolver` type declaration. This shortens the generated code and makes it more uniform. Functions with arguments are now also rendered as simple declarations. The implemented classes should still work the same way (and compile).