### PR TITLE
Add type resolvers

### DIFF
--- a/examples/graphql/schema/example.graphqls.ts
+++ b/examples/graphql/schema/example.graphqls.ts
@@ -1,7 +1,9 @@
 /* tslint:disable */
+import {GraphQLResolveInfo} from 'graphql';
 
 export namespace schema {
-    export type Resolver<Args, Result, Ctx> = Result | Promise<Result> | ((args: Args, context: Ctx) => Result | Promise<Result>)
+    export type GraphqlField<Args, Result, Ctx> = Result | Promise<Result> |
+        ((args: Args, context: Ctx, info: GraphQLResolveInfo) => Result | Promise<Result>)
 
     /**
      * The base query
@@ -10,7 +12,7 @@ export namespace schema {
         /**
          * Retrieve a person by name
          */
-        person?: Resolver<{name: string}, Person<Ctx> | undefined, Ctx>
+        person?: GraphqlField<{name: string}, Person<Ctx> | undefined, Ctx>
     }
 
     /**
@@ -20,14 +22,18 @@ export namespace schema {
         /**
          * The persons name
          */
-        name: Resolver<{}, string, Ctx>
+        name: GraphqlField<{}, string, Ctx>
         /**
          * The persons age in years
          */
-        age: Resolver<{}, number, Ctx>
+        age: GraphqlField<{}, number, Ctx>
         /**
          * Friendship relations to other persons
          */
-        friends?: Resolver<{}, Person<Ctx>[] | undefined, Ctx>
+        friends?: GraphqlField<{}, Person<Ctx>[] | undefined, Ctx>
+    }
+
+    export const defaultResolvers = {
+
     }
 }

--- a/package.json
+++ b/package.json
@@ -43,6 +43,8 @@
     "commander": "^2.9.0",
     "glob": "^7.1.1",
     "graphql": "^0.8.2",
+    "graphql-subscriptions": "^0.2.2",
+    "graphql-tools": "^0.9.0",
     "m-io": "^0.3.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -42,21 +42,21 @@
   "dependencies": {
     "commander": "^2.9.0",
     "glob": "^7.1.1",
-    "graphql": "^0.7.2",
-    "m-io": "^0.1.1"
+    "graphql": "^0.8.2",
+    "m-io": "^0.3.1"
   },
   "devDependencies": {
     "@types/chai": "^3.4.34",
     "@types/commander": "^2.3.30",
     "@types/glob": "^5.0.30",
-    "@types/graphql": "^0.7.2",
+    "@types/graphql": "^0.8.6",
     "@types/mocha": "^2.2.32",
-    "@types/node": "^6.0.46",
+    "@types/node": "^7.0.0",
     "chai": "^3.5.0",
-    "ghooks": "^1.0.3",
-    "mocha": "^2.3.3",
+    "ghooks": "^2.0.0",
+    "mocha": "^3.2.0",
     "thoughtful-release": "^0.3.0",
-    "ts-node": "^1.7.0",
+    "ts-node": "^2.0.0",
     "tslint": "^4.3.1",
     "tslint-config-standard": "^2.0.0",
     "tslint-eslint-rules": "^3.2.3",

--- a/src/render.ts
+++ b/src/render.ts
@@ -28,7 +28,8 @@ export class Renderer {
     render(root: Root): string {
         const namespace = source`
 export namespace schema {
-    export type Resolver<Args, Result, Ctx> = ${this.renderResolverDefinition()}
+    export type GraphqlField<Args, Result, Ctx> = Result | Promise<Result> |
+        ((args: Args, context: Ctx) => Result | Promise<Result>)
 
     ${this.renderEnums(root.data.__schema.types)}
     ${this.renderUnions(root.data.__schema.types)}
@@ -39,12 +40,6 @@ export namespace schema {
         return `/* tslint:disable */
 
 ${namespace.replace(/^\s+$/mg, '')}`
-    }
-
-    renderResolverDefinition() {
-        return 'Result | ' +
-               'Promise<Result> | ' +
-               '((args: Args, context: Ctx) => Result | Promise<Result>)'
     }
 
     /**
@@ -111,7 +106,7 @@ ${this.renderMember(field)}
         const resultType = optional ? `${type} | undefined` : type
         const argType = this.renderArgumentType(field.args || [])
         const name = optional ? field.name + '?' : field.name
-        return `${name}: Resolver<${argType}, ${resultType}, Ctx>`
+        return `${name}: GraphqlField<${argType}, ${resultType}, Ctx>`
     }
 
     /**

--- a/test/schemas/arguments.ts
+++ b/test/schemas/arguments.ts
@@ -7,4 +7,8 @@ export namespace schema {
     export interface Query<Ctx> {
         field1?: GraphqlField<{a: string, b: number}, string | undefined, Ctx>
     }
+
+    export const defaultResolvers = {
+
+    }
 }

--- a/test/schemas/arguments.ts
+++ b/test/schemas/arguments.ts
@@ -1,9 +1,10 @@
 /* tslint:disable */
 
 export namespace schema {
-    export type Resolver<Args, Result, Ctx> = Result | Promise<Result> | ((args: Args, context: Ctx) => Result | Promise<Result>)
+    export type GraphqlField<Args, Result, Ctx> = Result | Promise<Result> |
+        ((args: Args, context: Ctx) => Result | Promise<Result>)
 
     export interface Query<Ctx> {
-        field1?: Resolver<{a: string, b: number}, string | undefined, Ctx>
+        field1?: GraphqlField<{a: string, b: number}, string | undefined, Ctx>
     }
 }

--- a/test/schemas/enum.ts
+++ b/test/schemas/enum.ts
@@ -22,4 +22,8 @@ export namespace schema {
         state: GraphqlField<{}, STATE, Ctx>
         optionalState?: GraphqlField<{}, STATE | undefined, Ctx>
     }
+
+    export const defaultResolvers = {
+
+    }
 }

--- a/test/schemas/enum.ts
+++ b/test/schemas/enum.ts
@@ -1,7 +1,8 @@
 /* tslint:disable */
 
 export namespace schema {
-    export type Resolver<Args, Result, Ctx> = Result | Promise<Result> | ((args: Args, context: Ctx) => Result | Promise<Result>)
+    export type GraphqlField<Args, Result, Ctx> = Result | Promise<Result> |
+        ((args: Args, context: Ctx) => Result | Promise<Result>)
 
     export type STATE = 'OPEN' | 'CLOSED' | 'DELETED'
     export const STATE: {
@@ -18,7 +19,7 @@ export namespace schema {
     }
 
     export interface Query<Ctx> {
-        state: Resolver<{}, STATE, Ctx>
-        optionalState?: Resolver<{}, STATE | undefined, Ctx>
+        state: GraphqlField<{}, STATE, Ctx>
+        optionalState?: GraphqlField<{}, STATE | undefined, Ctx>
     }
 }

--- a/test/schemas/interface.ts
+++ b/test/schemas/interface.ts
@@ -1,32 +1,33 @@
 /* tslint:disable */
 
 export namespace schema {
-    export type Resolver<Args, Result, Ctx> = Result | Promise<Result> | ((args: Args, context: Ctx) => Result | Promise<Result>)
+    export type GraphqlField<Args, Result, Ctx> = Result | Promise<Result> |
+        ((args: Args, context: Ctx) => Result | Promise<Result>)
 
     /**
      * A character
      */
     export interface Character<Ctx> {
-        id: Resolver<{}, string, Ctx>
-        name: Resolver<{}, string, Ctx>
+        id: GraphqlField<{}, string, Ctx>
+        name: GraphqlField<{}, string, Ctx>
     }
     export interface Functional<Ctx> {
-        primaryFunction?: Resolver<{}, string | undefined, Ctx>
+        primaryFunction?: GraphqlField<{}, string | undefined, Ctx>
     }
 
     export interface Query<Ctx> {
-        characters?: Resolver<{}, (Character<Ctx> | undefined)[] | undefined, Ctx>
+        characters?: GraphqlField<{}, (Character<Ctx> | undefined)[] | undefined, Ctx>
     }
 
     export interface Human<Ctx> extends Character<Ctx> {
-        id: Resolver<{}, string, Ctx>
-        name: Resolver<{}, string, Ctx>
-        friends?: Resolver<{}, (Character<Ctx> | undefined)[] | undefined, Ctx>
+        id: GraphqlField<{}, string, Ctx>
+        name: GraphqlField<{}, string, Ctx>
+        friends?: GraphqlField<{}, (Character<Ctx> | undefined)[] | undefined, Ctx>
     }
 
     export interface Droid<Ctx> extends Character<Ctx>, Functional<Ctx> {
-        id: Resolver<{}, string, Ctx>
-        name: Resolver<{}, string, Ctx>
-        primaryFunction?: Resolver<{}, string | undefined, Ctx>
+        id: GraphqlField<{}, string, Ctx>
+        name: GraphqlField<{}, string, Ctx>
+        primaryFunction?: GraphqlField<{}, string | undefined, Ctx>
     }
 }

--- a/test/schemas/interface.ts
+++ b/test/schemas/interface.ts
@@ -20,14 +20,29 @@ export namespace schema {
     }
 
     export interface Human<Ctx> extends Character<Ctx> {
+        __typename: 'Human'
         id: GraphqlField<{}, string, Ctx>
         name: GraphqlField<{}, string, Ctx>
         friends?: GraphqlField<{}, (Character<Ctx> | undefined)[] | undefined, Ctx>
     }
 
     export interface Droid<Ctx> extends Character<Ctx>, Functional<Ctx> {
+        __typename: 'Droid'
         id: GraphqlField<{}, string, Ctx>
         name: GraphqlField<{}, string, Ctx>
         primaryFunction?: GraphqlField<{}, string | undefined, Ctx>
+    }
+
+    export const defaultResolvers = {
+        Character: {
+            __resolveType(obj) {
+                return obj.__typename
+            }
+        },
+        Functional: {
+            __resolveType(obj) {
+                return obj.__typename
+            }
+        }
     }
 }

--- a/test/schemas/mutation.ts
+++ b/test/schemas/mutation.ts
@@ -1,7 +1,8 @@
 /* tslint:disable */
 
 export namespace schema {
-    export type Resolver<Args, Result, Ctx> = Result | Promise<Result> | ((args: Args, context: Ctx) => Result | Promise<Result>)
+    export type GraphqlField<Args, Result, Ctx> = Result | Promise<Result> |
+        ((args: Args, context: Ctx) => Result | Promise<Result>)
 
     /**
      * Set a key to a value
@@ -11,16 +12,16 @@ export namespace schema {
         value?: string
     }
     export interface Query<Ctx> {
-        values?: Resolver<{}, (KeyValue<Ctx> | undefined)[] | undefined, Ctx>
+        values?: GraphqlField<{}, (KeyValue<Ctx> | undefined)[] | undefined, Ctx>
     }
 
     export interface KeyValue<Ctx> {
-        key: Resolver<{}, string, Ctx>
-        value?: Resolver<{}, string | undefined, Ctx>
+        key: GraphqlField<{}, string, Ctx>
+        value?: GraphqlField<{}, string | undefined, Ctx>
     }
 
     export interface Mutation<Ctx> {
-        simpleMutation?: Resolver<{key: string, value: string}, (KeyValue<Ctx> | undefined)[] | undefined, Ctx>
-        commandMutation?: Resolver<{cmd: SetValueCommand}, (KeyValue<Ctx> | undefined)[] | undefined, Ctx>
+        simpleMutation?: GraphqlField<{key: string, value: string}, (KeyValue<Ctx> | undefined)[] | undefined, Ctx>
+        commandMutation?: GraphqlField<{cmd: SetValueCommand}, (KeyValue<Ctx> | undefined)[] | undefined, Ctx>
     }
 }

--- a/test/schemas/mutation.ts
+++ b/test/schemas/mutation.ts
@@ -24,4 +24,8 @@ export namespace schema {
         simpleMutation?: GraphqlField<{key: string, value: string}, (KeyValue<Ctx> | undefined)[] | undefined, Ctx>
         commandMutation?: GraphqlField<{cmd: SetValueCommand}, (KeyValue<Ctx> | undefined)[] | undefined, Ctx>
     }
+
+    export const defaultResolvers = {
+
+    }
 }

--- a/test/schemas/required.ts
+++ b/test/schemas/required.ts
@@ -1,20 +1,21 @@
 /* tslint:disable */
 
 export namespace schema {
-    export type Resolver<Args, Result, Ctx> = Result | Promise<Result> | ((args: Args, context: Ctx) => Result | Promise<Result>)
+    export type GraphqlField<Args, Result, Ctx> = Result | Promise<Result> |
+        ((args: Args, context: Ctx) => Result | Promise<Result>)
 
     export interface Query<Ctx> {
-        requiredStringField: Resolver<{}, string, Ctx>
-        optionalStringField?: Resolver<{}, string | undefined, Ctx>
-        requiredIntField: Resolver<{}, number, Ctx>
-        requiredObjectField: Resolver<{}, A<Ctx>, Ctx>
-        requiredListOfOptionals: Resolver<{}, (string | undefined)[], Ctx>
-        optionalListOfOptionals?: Resolver<{}, (string | undefined)[] | undefined, Ctx>
-        requiredListOfRequired: Resolver<{}, string[], Ctx>
-        optionalListOfRequired?: Resolver<{}, string[] | undefined, Ctx>
+        requiredStringField: GraphqlField<{}, string, Ctx>
+        optionalStringField?: GraphqlField<{}, string | undefined, Ctx>
+        requiredIntField: GraphqlField<{}, number, Ctx>
+        requiredObjectField: GraphqlField<{}, A<Ctx>, Ctx>
+        requiredListOfOptionals: GraphqlField<{}, (string | undefined)[], Ctx>
+        optionalListOfOptionals?: GraphqlField<{}, (string | undefined)[] | undefined, Ctx>
+        requiredListOfRequired: GraphqlField<{}, string[], Ctx>
+        optionalListOfRequired?: GraphqlField<{}, string[] | undefined, Ctx>
     }
 
     export interface A<Ctx> {
-        name: Resolver<{}, string, Ctx>
+        name: GraphqlField<{}, string, Ctx>
     }
 }

--- a/test/schemas/required.ts
+++ b/test/schemas/required.ts
@@ -18,4 +18,8 @@ export namespace schema {
     export interface A<Ctx> {
         name: GraphqlField<{}, string, Ctx>
     }
+
+    export const defaultResolvers = {
+
+    }
 }

--- a/test/schemas/scalars.ts
+++ b/test/schemas/scalars.ts
@@ -1,13 +1,14 @@
 /* tslint:disable */
 
 export namespace schema {
-    export type Resolver<Args, Result, Ctx> = Result | Promise<Result> | ((args: Args, context: Ctx) => Result | Promise<Result>)
+    export type GraphqlField<Args, Result, Ctx> = Result | Promise<Result> |
+        ((args: Args, context: Ctx) => Result | Promise<Result>)
 
     export interface Query<Ctx> {
-        stringField?: Resolver<{}, string | undefined, Ctx>
-        booleanField?: Resolver<{}, boolean | undefined, Ctx>
-        intField?: Resolver<{}, number | undefined, Ctx>
-        floatField?: Resolver<{}, number | undefined, Ctx>
-        idField?: Resolver<{}, string | undefined, Ctx>
+        stringField?: GraphqlField<{}, string | undefined, Ctx>
+        booleanField?: GraphqlField<{}, boolean | undefined, Ctx>
+        intField?: GraphqlField<{}, number | undefined, Ctx>
+        floatField?: GraphqlField<{}, number | undefined, Ctx>
+        idField?: GraphqlField<{}, string | undefined, Ctx>
     }
 }

--- a/test/schemas/scalars.ts
+++ b/test/schemas/scalars.ts
@@ -11,4 +11,8 @@ export namespace schema {
         floatField?: GraphqlField<{}, number | undefined, Ctx>
         idField?: GraphqlField<{}, string | undefined, Ctx>
     }
+
+    export const defaultResolvers = {
+
+    }
 }

--- a/test/schemas/simpleSchema.ts
+++ b/test/schemas/simpleSchema.ts
@@ -30,4 +30,8 @@ export namespace schema {
     export interface TypeB<Ctx> {
         nested?: GraphqlField<{}, (TypeA<Ctx> | undefined)[] | undefined, Ctx>
     }
+
+    export const defaultResolvers = {
+
+    }
 }

--- a/test/schemas/simpleSchema.ts
+++ b/test/schemas/simpleSchema.ts
@@ -1,17 +1,18 @@
 /* tslint:disable */
 
 export namespace schema {
-    export type Resolver<Args, Result, Ctx> = Result | Promise<Result> | ((args: Args, context: Ctx) => Result | Promise<Result>)
+    export type GraphqlField<Args, Result, Ctx> = Result | Promise<Result> |
+        ((args: Args, context: Ctx) => Result | Promise<Result>)
 
     export interface Query<Ctx> {
         /**
          * A field description
          */
-        field1?: Resolver<{}, TypeA<Ctx> | undefined, Ctx>
+        field1?: GraphqlField<{}, TypeA<Ctx> | undefined, Ctx>
         /**
          * Another field description
          */
-        field2?: Resolver<{}, TypeB<Ctx> | undefined, Ctx>
+        field2?: GraphqlField<{}, TypeB<Ctx> | undefined, Ctx>
     }
 
     /**
@@ -19,14 +20,14 @@ export namespace schema {
      * Multiline description
      */
     export interface TypeA<Ctx> {
-        name?: Resolver<{}, string | undefined, Ctx>
-        size?: Resolver<{}, number | undefined, Ctx>
+        name?: GraphqlField<{}, string | undefined, Ctx>
+        size?: GraphqlField<{}, number | undefined, Ctx>
     }
 
     /**
      * Another more complex type
      */
     export interface TypeB<Ctx> {
-        nested?: Resolver<{}, (TypeA<Ctx> | undefined)[] | undefined, Ctx>
+        nested?: GraphqlField<{}, (TypeA<Ctx> | undefined)[] | undefined, Ctx>
     }
 }

--- a/test/schemas/union.graphqls
+++ b/test/schemas/union.graphqls
@@ -11,5 +11,5 @@ union AOrB = A | B
 
 type Query {
   single: Single
-  aOrB: AOrB
+  aOrB(a: Int): AOrB
 }

--- a/test/schemas/union.ts
+++ b/test/schemas/union.ts
@@ -17,10 +17,25 @@ export namespace schema {
     }
 
     export interface A<Ctx> {
+        __typename: 'A'
         aName?: GraphqlField<{}, string | undefined, Ctx>
     }
 
     export interface B<Ctx> {
+        __typename: 'B'
         bName?: GraphqlField<{}, string | undefined, Ctx>
+    }
+
+    export const defaultResolvers = {
+        Single: {
+            __resolveType(obj) {
+                return obj.__typename
+            }
+        },
+        AOrB: {
+            __resolveType(obj) {
+                return obj.__typename
+            }
+        }
     }
 }

--- a/test/schemas/union.ts
+++ b/test/schemas/union.ts
@@ -13,7 +13,7 @@ export namespace schema {
 
     export interface Query<Ctx> {
         single?: GraphqlField<{}, Single<Ctx> | undefined, Ctx>
-        aOrB?: GraphqlField<{}, AOrB<Ctx> | undefined, Ctx>
+        aOrB?: GraphqlField<{a: number}, AOrB<Ctx> | undefined, Ctx>
     }
 
     export interface A<Ctx> {

--- a/test/schemas/union.ts
+++ b/test/schemas/union.ts
@@ -1,7 +1,8 @@
 /* tslint:disable */
 
 export namespace schema {
-    export type Resolver<Args, Result, Ctx> = Result | Promise<Result> | ((args: Args, context: Ctx) => Result | Promise<Result>)
+    export type GraphqlField<Args, Result, Ctx> = Result | Promise<Result> |
+        ((args: Args, context: Ctx) => Result | Promise<Result>)
 
     export type Single<Ctx> = A<Ctx>
 
@@ -11,15 +12,15 @@ export namespace schema {
     export type AOrB<Ctx> = A<Ctx> | B<Ctx>
 
     export interface Query<Ctx> {
-        single?: Resolver<{}, Single<Ctx> | undefined, Ctx>
-        aOrB?: Resolver<{}, AOrB<Ctx> | undefined, Ctx>
+        single?: GraphqlField<{}, Single<Ctx> | undefined, Ctx>
+        aOrB?: GraphqlField<{}, AOrB<Ctx> | undefined, Ctx>
     }
 
     export interface A<Ctx> {
-        aName?: Resolver<{}, string | undefined, Ctx>
+        aName?: GraphqlField<{}, string | undefined, Ctx>
     }
 
     export interface B<Ctx> {
-        bName?: Resolver<{}, string | undefined, Ctx>
+        bName?: GraphqlField<{}, string | undefined, Ctx>
     }
 }


### PR DESCRIPTION
This pull request adds autogenerated resolvers for unions and interface. Those are needed by graphql to execute queries against schemas that contain these structures.

* In order to make them work properly it also updates the dependencies (no changes to the code were needed)
* the type `Resolver` has been renamed to `GraphqlField` because they are not really resolvers.
* Add usability specs for unions and interfaces that show how the default resolvers are used.

With this pull request the generated code can now be used with apollo as well.